### PR TITLE
Feature: better fullscreen mode

### DIFF
--- a/soda/src/SdlGlue.cpp
+++ b/soda/src/SdlGlue.cpp
@@ -285,7 +285,7 @@ bool GetFullScreen() {
 
 void SetFullScreen(bool fullScreen) {
 	if (fullScreen) {
-		SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN);
+		SDL_SetWindowFullscreen(mainWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
 	} else {
 		SDL_SetWindowFullscreen(mainWindow, 0);
 		SDL_SetWindowSize(mainWindow, windowWidth, windowHeight);

--- a/soda/src/TextDisplay.cpp
+++ b/soda/src/TextDisplay.cpp
@@ -10,7 +10,7 @@
 #include "UnicodeUtil.h"
 #include "Color.h"
 #include <SDL2/SDL.h>
-#include <SDL2_image/SDL_image.h>  // must be <SDL2_image/SDL_image.h> on some platforms
+#include <SDL2/SDL_image.h>  // must be <SDL2_image/SDL_image.h> on some platforms
 
 using namespace MiniScript;
 using namespace SdlGlue;


### PR DESCRIPTION
This tiny PR changes the fullscreen flag to use "windowed mode".

On Mac OS X this has the following advantages:
* It allows to Cmd-Tab back to other applications
* It integrates better with "Mission Control", being able to re-arrange desktops

If this flag is not set, the user cannot "escape" the running application. Cmd-Tab is not possible, etc. If the app does not provide a way to exit it, the only way to exit this situation is to reboot the computer.

IMPORTANT: I have not tested this on Linux / Windows.