### PR TITLE
Windows Environment build fix,and minor fix(SDL_mixer include in Linux )

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,9 +6,10 @@ Soda is a command-line program written in C++ and using SDL.  On most systems th
 
 1. Make sure you have a C++ toolchain installed.  Currently, the Linux/Mac makefile assumes this is accessed via a `gcc` command.  You can use `gcc -v` to verify that such a compiler is installed, and check the version number.  On Windows, install the [Visual Studio Command-Line Tools](https://docs.microsoft.com/en-us/cpp/build/walkthrough-compiling-a-native-cpp-program-on-the-command-line?view=vs-2019).
 
-2. Install the **SDL2** and **SDL2_image** development libraries.  For details, see:
+2. Install the **SDL2** , **SDL2_image** and **SDL2_mixer** development libraries.  For details, see:
 - https://wiki.libsdl.org/Installation
 - https://github.com/libsdl-org/SDL_image
+- https://github.com/libsdl-org/SDL_mixer
 
 ## Build Steps (Mac/Linux)
 
@@ -23,7 +24,13 @@ Soda is a command-line program written in C++ and using SDL.  On most systems th
 
 0. Run the **Developer Command Prompt for VS**.
 1. `cd soda` to change to the _soda_ subdirectory (next to this document).
-2. `cd src` to move to the _soda\src_ directory.
-3. `cl /EHsc /wd4068 *.cpp MiniScript/*.cpp /Fesoda.exe`
+2. `build_win.bat` to do the build.
 
-That should do it _if_ the SDL paths are all sorted out.  Which they probably aren't.  This is a work in progress.
+When you run this program, it will display the execution location of the tool 
+and the bitness of the exe file it will generate.
+If an include or library cannot be loaded during the build, 
+look at the message that is displayed and check whether the library 
+or include file exists in the folder associated with the executable file.
+
+That should do it _if_ the SDL paths are all sorted out.  
+Which they probably aren't.  This is a work in progress.

--- a/soda/Makefile-Linux
+++ b/soda/Makefile-Linux
@@ -13,7 +13,7 @@ CPPFLAGS=-std=c++11 $(CFLAGS)
 LFLAGS=
 
 # Libraries
-LIBS=-lstdc++ -lm -lSDL2_image -lSDL2
+LIBS=-lstdc++ -lm -lSDL2_image -lSDL2 -lSDL2_mixer
 
 # Include paths: note that we expect to find the SDL2 directory (containing
 # all SDL2 headers), or a symlink to it, at /usr/include/SDL2.  If you

--- a/soda/build_win.bat
+++ b/soda/build_win.bat
@@ -1,0 +1,66 @@
+@echo off
+cls
+
+echo --------              --------
+echo -------- build start. --------
+echo --------              --------
+
+:check
+
+if defined VSCMD_ARG_TGT_ARCH (
+	goto build
+)
+
+:nobuild
+	echo error!
+	echo this prompt calls no VS BuildTools.
+	echo Please execute build_win.bat in Developer Command Prompt 
+	echo or x86/x64 Native Tools Command Prompt
+	echo --------- build stopped. --------
+	echo Please press Enter to continue the program...
+	set /p dummy=
+	goto finish
+
+
+:build
+	echo %VCToolsInstallDir% is BuildTools installed path.
+	echo this prompt calls %VSCMD_ARG_TGT_ARCH% build application.
+	echo If you are told that a library or include file does not exist, 
+	echo please check the "include" and "lib" in the above path.
+
+	echo -------- move folder. --------
+	rem move to src folder.
+	@echo on
+	cd src
+	@echo off
+	
+	rem compile command.
+	echo -------- compile programs. --------
+	@echo on
+	cl -I . -I MiniScript -I compiledData -I SDL2 /EHsc /wd4068 /source-charset:utf-8 /execution-charset:utf-8 ./*.cpp ./MiniScript/*.cpp ./compiledData/*.c /Fesoda.exe SDL2.lib SDL2main.lib SDL2_image.lib SDL2_mixer.lib Shell32.lib /link /SUBSYSTEM:console
+	@echo off
+	
+	rem move executable file to upper folder.
+	if %ERRORLEVEL% equ 0 (
+		echo -------- build succeed. --------
+		echo this build program made %VSCMD_ARG_TGT_ARCH% executable file.
+		if %VSCMD_ARG_TGT_ARCH% equ x86 (
+			rem 32bit exe file.
+			move soda.exe ../soda_x86.exe
+		) else if %VSCMD_ARG_TGT_ARCH% equ x64 (
+			rem 64bit exe file.
+			move soda.exe ../soda_x64.exe
+		) else (
+			move soda.exe ../soda.exe
+		)
+	) else (
+		echo -------- build failed. --------
+	)
+
+	rem leave src folder.
+	cd ..
+
+:finish
+	echo -------- build program end. --------
+
+

--- a/soda/build_win.bat
+++ b/soda/build_win.bat
@@ -24,9 +24,9 @@ if defined VSCMD_ARG_TGT_ARCH (
 
 :build
 	echo %VCToolsInstallDir% is BuildTools installed path.
-	echo this prompt calls %VSCMD_ARG_TGT_ARCH% build application.
+	echo this prompt calls %VSCMD_ARG_TGT_ARCH% build applications.
 	echo If you are told that a library or include file does not exist, 
-	echo please check the "include" and "lib" in the above path.
+	echo please check the "include" and "lib" folders in the above path.
 
 	echo -------- move folder. --------
 	rem move to src folder.
@@ -51,6 +51,7 @@ if defined VSCMD_ARG_TGT_ARCH (
 			rem 64bit exe file.
 			move soda.exe ../soda_x64.exe
 		) else (
+			rem other build arch.(I think that is not existed)
 			move soda.exe ../soda.exe
 		)
 	) else (

--- a/soda/src/PixelDisplay.cpp
+++ b/soda/src/PixelDisplay.cpp
@@ -87,7 +87,7 @@ static double LineSegIntersectFraction(Vector2 p1, Vector2 p2, Vector2 p3, Vecto
 	// Reference: http://paulbourke.net/geometry/lineline2d/
 	double num = (p4.x - p3.x) * (p1.y - p3.y) - (p4.y - p3.y) * (p1.x - p3.x);
 	double denom=(p4.y - p3.y) * (p2.x - p1.x) - (p4.x - p3.x) * (p2.y - p1.y);
-	if (denom == 0.0f) return 0.0f / 0.0f;
+	if (denom == 0.0f) return 0.0f ;
 	return num / denom;
 }
 

--- a/soda/src/SdlUtils.h
+++ b/soda/src/SdlUtils.h
@@ -14,6 +14,10 @@
 #if _WIN32 || _WIN64
 	#include <SDL2/SDL_image.h>
 #else
+	// In some cases, this path may not be accessible on other platforms, 
+	// so please rewrite the path correctly.
+	// (This may also be the case for other Linux versions. Confirmed on Ubuntu.)
+	// Or add OS information in a branching format like the directive command above.
 	#include <SDL_image.h>
 #endif
 

--- a/soda/src/SdlUtils.h
+++ b/soda/src/SdlUtils.h
@@ -10,7 +10,13 @@
 // some platforms but not others.
 
 #include <SDL2/SDL.h>
-#include <SDL_image.h>
+
+#if _WIN32 || _WIN64
+	#include <SDL2/SDL_image.h>
+#else
+	#include <SDL_image.h>
+#endif
+
 #include <SDL2/SDL_gamecontroller.h>
 
 #include "QA.h"

--- a/soda/src/main.cpp
+++ b/soda/src/main.cpp
@@ -321,8 +321,11 @@ void RunIntegrationTests(String path) {
 	Print("\nIntegration tests complete.\n");
 }
 
-
-void PrepareShellArgs(int argc, char* argv[], int startingAt) {
+#if _WIN32 || _WIN64
+	void PrepareShellArgs(int argc, char* argv[], int startingAt) {
+#else
+	void PrepareShellArgs(int argc, const char* argv[], int startingAt) {
+#endif
 	ValueList args;
 	for (int i=startingAt; i<argc; i++) {
 		args.Add(String(argv[i]));
@@ -330,7 +333,13 @@ void PrepareShellArgs(int argc, char* argv[], int startingAt) {
 	shellArgs = args;
 }
 
-int main(int argc, char * argv[]) {
+#if _WIN32 || _WIN64
+	int main(int argc, char * argv[]) {
+#else
+	int main(int argc, const char * argv[]) {
+#endif
+
+		
 #if(DEBUG)
 	std::cout << "StringStorage instances at start (from static keywords, etc.): " << StringStorage::instanceCount << std::endl;
 	std::cout << "total RefCountedStorage instances at start (from static keywords, etc.): " << RefCountedStorage::instanceCount << std::endl;

--- a/soda/src/main.cpp
+++ b/soda/src/main.cpp
@@ -321,7 +321,8 @@ void RunIntegrationTests(String path) {
 	Print("\nIntegration tests complete.\n");
 }
 
-void PrepareShellArgs(int argc, const char* argv[], int startingAt) {
+
+void PrepareShellArgs(int argc, char* argv[], int startingAt) {
 	ValueList args;
 	for (int i=startingAt; i<argc; i++) {
 		args.Add(String(argv[i]));
@@ -329,8 +330,7 @@ void PrepareShellArgs(int argc, const char* argv[], int startingAt) {
 	shellArgs = args;
 }
 
-int main(int argc, const char * argv[]) {
-	
+int main(int argc, char * argv[]) {
 #if(DEBUG)
 	std::cout << "StringStorage instances at start (from static keywords, etc.): " << StringStorage::instanceCount << std::endl;
 	std::cout << "total RefCountedStorage instances at start (from static keywords, etc.): " << RefCountedStorage::instanceCount << std::endl;


### PR DESCRIPTION
This PR adds settings for building in a Windows environment and for building in the current Linux environment.

1-1. Advantage 1
Building in a Windows environment is possible.

1-2. Modifications
Certain functions have been reformatted for the Windows compiler, and are reflected only when compiled with a Windows tool.
This is a specification of SDL and Windows programs, and only main functions with specific arguments work, so modifications are necessary.
And a batch script tool has been created to simplify compilation. "build_win.bat"
Based on the above, the build procedure on Windows in "BUILDING.txt" has been modified.

2-1. Advantage 2
SDL_mixer libraries can now be loaded.

2-2. Modifications
Modified Makefile for Linux.
Based on the above, the build procedure in "BUILDING.txt" has been modified to run SDL_mixer.

2-3. Other
Not tested on MacOS.
However, when I checked the Makefile, I found that SDL_mixer was included, so I don't think there's a problem.