### PR TITLE
Build description fixed for Windows.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -27,6 +27,8 @@ Soda is a command-line program written in C++ and using SDL.  On most systems th
 This procedure depends on the environment of the person building it, so I can't go into detail.
 However, here are some hints:
 If you store the SDL files in the storage location for include files and library files associated with the environment variable "VCToolsInstallDir", they will be recognized.
+Alternatively, you may want to store your include and library files in "soda/src".
+In either case, the include files should be placed in the SDL2 folder.
 3. Launch **DeveloperCommandPrompt for VC 20xx**
 4. command `cd soda` to change to the _soda_ subdirectory (next to this document).
 5. command `build_win.bat`
@@ -38,9 +40,9 @@ If an include or library cannot be loaded during the build,
 look at the message that is displayed and check whether the library 
 or include file exists in the folder associated with the executable file.
 
-### usage
+### Launch Soda
 Place SDL2.dll, SDL2_image.dll, and SDL2_mixer.dll in the same folder as the executable file and launch either soda_x86.exe or soda_x64.exe.
 
-### warning. 
+### Warning. 
 That should do it _if_ the SDL paths are all sorted out.  
 Which they probably aren't.  This is a work in progress.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,5 +38,9 @@ If an include or library cannot be loaded during the build,
 look at the message that is displayed and check whether the library 
 or include file exists in the folder associated with the executable file.
 
+### usage
+Place SDL2.dll, SDL2_image.dll, and SDL2_mixer.dll in the same folder as the executable file and launch either soda_x86.exe or soda_x64.exe.
+
+### warning. 
 That should do it _if_ the SDL paths are all sorted out.  
 Which they probably aren't.  This is a work in progress.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,7 +7,7 @@ Soda is a command-line program written in C++ and using SDL.  On most systems th
 1. Make sure you have a C++ toolchain installed.  Currently, the Linux/Mac makefile assumes this is accessed via a `gcc` command.  You can use `gcc -v` to verify that such a compiler is installed, and check the version number.  On Windows, install the [Visual Studio Command-Line Tools](https://docs.microsoft.com/en-us/cpp/build/walkthrough-compiling-a-native-cpp-program-on-the-command-line?view=vs-2019).
 
 2. Install the **SDL2** , **SDL2_image** and **SDL2_mixer** development libraries.  For details, see:
-- https://wiki.libsdl.org/Installation
+- https://wiki.libsdl.org/SDL2/Installation
 - https://github.com/libsdl-org/SDL_image
 - https://github.com/libsdl-org/SDL_mixer
 
@@ -22,9 +22,15 @@ Soda is a command-line program written in C++ and using SDL.  On most systems th
 
 ## Build Steps (Windows)
 
-0. Run the **Developer Command Prompt for VS**.
-1. `cd soda` to change to the _soda_ subdirectory (next to this document).
-2. `build_win.bat` to do the build.
+1. Install build tools .
+2. Please store the SDL include file and library file in a location that is compatible with the DeveloperCommandPrompt.
+This procedure depends on the environment of the person building it, so I can't go into detail.
+However, here are some hints:
+If you store the SDL files in the storage location for include files and library files associated with the environment variable "VCToolsInstallDir", they will be recognized.
+3. Launch **DeveloperCommandPrompt for VC 20xx**
+4. command `cd soda` to change to the _soda_ subdirectory (next to this document).
+5. command `build_win.bat`
+6. The executable file will be written into the soda folder.
 
 When you run this program, it will display the execution location of the tool 
 and the bitness of the exe file it will generate.

--- a/soda/build_win.bat
+++ b/soda/build_win.bat
@@ -27,6 +27,8 @@ if defined VSCMD_ARG_TGT_ARCH (
 	echo this prompt calls %VSCMD_ARG_TGT_ARCH% build applications.
 	echo If you are told that a library or include file does not exist, 
 	echo please check the "include" and "lib" folders in the above path.
+	echo Alternatively, you may want to store your include and library files in "soda/src".
+	echo In either case, the include files should be placed in the SDL2 folder.
 
 	echo -------- move folder. --------
 	rem move to src folder.


### PR DESCRIPTION
This PR provides more detailed instructions and build messages for building Soda on Windows.

The following improvements have been made to the Windows build environment.

-Revised the wording of BUILDING.TXT
-Presented a different build method (installation of SDL2 include files and library files)
-Modified build_win.bat (provided more detailed instructions)

We have confirmed that SDL2 files can be built if they are stored in the src folder, so we present this method.
However, since it cannot fully accommodate the differences between 32bit/64bit environments, we present this as a method that will at least allow you to build.

