### PR TITLE
Reworked BUILLDING.ms and build_win.bat to be easy to follow through

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,36 +1,41 @@
 # How to Build Soda
 
-Soda is a command-line program written in C++ and using SDL.  On most systems the build is fairly straightforward once the prerequisites are met.
+Soda is a command-line program written in C++ and using [SDL](https://www.libsdl.org/).  On most systems the build is fairly straightforward once the SDL libraries are setup.
 
-## Prerequisites
+## Build Steps **Windows**
 
-1. Make sure you have a C++ toolchain installed.  Currently, the Linux/Mac makefile assumes this is accessed via a `gcc` command.  You can use `gcc -v` to verify that such a compiler is installed, and check the version number.  On Windows, install the [Visual Studio Command-Line Tools](https://docs.microsoft.com/en-us/cpp/build/walkthrough-compiling-a-native-cpp-program-on-the-command-line?view=vs-2019).
+1. Install the [Visual Studio Command-Line Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022).
+2. Run the **Developer Command Prompt for VS** from start. 
+3. Clone this repository in `C:\` folder or download this repository as a zip, and  extract the contents  to `C:\` drive.
+4. Download VC release versions of [**SDL2**](https://github.com/libsdl-org/SDL/releases) , [**SDL2_image**](https://github.com/libsdl-org/SDL_image/releases) and [**SDL2_mixer**](https://github.com/libsdl-org/SDL_mixer/releases) for example sdl-devel-vc.zip. (Make sure to download the SDL2 versions and not SDL3 versions) 
+5. Unzip all three libraries.
+6. Create a folder named `SDL2` at `C:\` and Copy the contents of the zip files to this folder. for example 
+7. For example your directory structure would be something like this.
+   - SDL2
+      - SDL2_2
+      - SDL2_image
+      - SDL2_mixer
+8.  Place this SDL2 folder in `C:\soda\src`
+9.  Type `build_win.bat` in the command prompt to do the build.
+10. Place **SDL2.dll**, **SDL2_image.dll**, and **SDL2_mixer.dll** in `C:\soda` and launch either  `soda_x64.exe ".\tests\balls.ms"` or `soda_x86.exe ".\tests\balls.ms"`
+    
+## Build Steps **Linux**
 
-2. Install the **SDL2** , **SDL2_image** and **SDL2_mixer** development libraries.  For details, see:
-- https://wiki.libsdl.org/Installation
-- https://github.com/libsdl-org/SDL_image
-- https://github.com/libsdl-org/SDL_mixer
+1. run `sudo apt-get install libsdl2-dev | apt-get install libsdl2-image-dev | apt-get install libsdl2-mixer-dev` in a terminal window. This will install the required libraries.
+2. Clone this repository in a folder or download this repository as a zip, and  extract the contents. 
+3. `cd soda` to change to the _soda_ subdirectory next to this document. (soda-main\soda)
+4. `./configure` to run the _configure_ script. This will make a new build directory.
+5. `cd Build` to change to the _soda/Build_ subdirectory.
+6. `make` to build the soda executable.  If all goes well, you will now have a _soda_ executable in the Build directory.
+7. `sudo make install` to copy the executable into _/usr/local/bin_. This will allow  you  to run soda like any other program by just typing soda in your terminal window.
+8. run soda `./tests/balls.ms` to run this built in example (You can browse and test the other examples on your own).
 
-## Build Steps (Mac/Linux)
-
-1. `cd soda` to change to the _soda_ subdirectory (next to this document).
-2. `./configure` to run the _configure_ script.  This will detect what platform you are on, and copy the appropriate makefile to the Build directory.
-3. `cd Build` to change to the _soda/Build_ subdirectory.
-4. `make` to build the soda executable.  If all goes well, you will now have a _soda_ executable in the Build directory.
-5. (optional) `sudo make install` to copy the executable into _/usr/local/bin_, making it easily accessible from any directory (assuming this is in your PATH, as is usually the case).
-6. (optional) `make clean` to clean intermediate products out of the Build directory.
-
-## Build Steps (Windows)
-
-0. Run the **Developer Command Prompt for VS**.
-1. `cd soda` to change to the _soda_ subdirectory (next to this document).
-2. `build_win.bat` to do the build.
-
-When you run this program, it will display the execution location of the tool 
-and the bitness of the exe file it will generate.
-If an include or library cannot be loaded during the build, 
-look at the message that is displayed and check whether the library 
-or include file exists in the folder associated with the executable file.
-
-That should do it _if_ the SDL paths are all sorted out.  
-Which they probably aren't.  This is a work in progress.
+## Build Steps **Mac**
+1. Install Homebrew if you don't already have it. Open your terminal and run the command `brew install sdl2 sdl2_image sdl2_mixer`
+2. Clone this repository in a folder or download this repository as a zip, and  extract the contents. 
+3. `cd soda` to change to the _soda_ subdirectory next to this document. (soda-main\soda)
+4. `./configure` to run the _configure_ script. This will make a new build directory.
+5. `cd Build` to change to the _soda/Build_ subdirectory.
+6. `make` to build the soda executable.  If all goes well, you will now have a _soda_ executable in the Build directory.
+7. `sudo make install` to copy the executable into _/usr/local/bin_. This will allow  you  to run soda like any other program by just typing soda in your terminal window.
+8. run soda `./tests/balls.ms` to run this built in example (You can browse and test the other examples on your own).

--- a/soda/build_win.bat
+++ b/soda/build_win.bat
@@ -37,7 +37,7 @@ if defined VSCMD_ARG_TGT_ARCH (
 	rem compile command.
 	echo -------- compile programs. --------
 	@echo on
-	cl -I . -I MiniScript -I compiledData -I SDL2 /EHsc /wd4068 /source-charset:utf-8 /execution-charset:utf-8 ./*.cpp ./MiniScript/*.cpp ./compiledData/*.c /Fesoda.exe SDL2.lib SDL2main.lib SDL2_image.lib SDL2_mixer.lib Shell32.lib /link /SUBSYSTEM:console
+	cl -I . -I MiniScript -I compiledData -I SDL2 /EHsc /wd4068 /source-charset:utf-8 /execution-charset:utf-8 ./*.cpp ./MiniScript/*.cpp ./compiledData/*.c /Fesoda.exe /link /LIBPATH:./SDL2/SDL2_2/lib/%VSCMD_ARG_TGT_ARCH% /LIBPATH:./SDL2/SDL2_image/lib/%VSCMD_ARG_TGT_ARCH% /LIBPATH:./SDL2/SDL2_mixer/lib/%VSCMD_ARG_TGT_ARCH% SDL2.lib SDL2main.lib SDL2_image.lib SDL2_mixer.lib Shell32.lib /SUBSYSTEM:console
 	@echo off
 	
 	rem move executable file to upper folder.


### PR DESCRIPTION
Rewrote BUILDING.md to include more detailed install instructions for all platforms.

Changed the compile command in build_win.bat to look for SDL files in  SDL2_2, SDL2_image and SDL2_mixer, instead of in src directly